### PR TITLE
Bump version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -17,14 +17,11 @@
     "package.json"
   ],
   "dependencies": {
-    "purescript-prelude": "^2.3.0",
-    "purescript-eff": "^2.0.0",
-    "purescript-node-fs": "^3.0.0",
-    "purescript-functions": "^2.0.0",
-    "purescript-nullable": "^2.0.0",
-    "purescript-either": "^2.1.0"
-  },
-  "resolutions": {
-    "purescript-eff": "^2.0.0"
+    "purescript-prelude": "^3.0.0",
+    "purescript-eff": "^3.0.0",
+    "purescript-node-fs": "^4.0.0",
+    "purescript-functions": "^3.0.0",
+    "purescript-nullable": "^3.0.0",
+    "purescript-either": "^3.0.0"
   }
 }


### PR DESCRIPTION
This PR simply bumps bower dependencies to more recent versions in the Purescript ecosystem to allow conflict-resolution-free development.